### PR TITLE
Bump gitleaks version from v7.2.0 to v7.5.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: "Look behind depth"
 runs:
   using: "docker"
-  image: "docker://eu.gcr.io/mettle-bank/zricethezav/gitleaks:v7.2.0"
+  image: "docker://eu.gcr.io/mettle-bank/zricethezav/gitleaks:v7.5.0"
   args:
     - gitleaks
     - --depth=${{ inputs.depth }}


### PR DESCRIPTION
Towards https://eeveebank.atlassian.net/browse/PE-28